### PR TITLE
Change the access level of UserInfo's constructor

### DIFF
--- a/src/com/microsoftopentechnologies/auth/UserInfo.java
+++ b/src/com/microsoftopentechnologies/auth/UserInfo.java
@@ -39,7 +39,7 @@ public class UserInfo implements Serializable {
     private final String uniqueName;
     private final String tenantId;
 
-    private UserInfo(final String userId,
+    public UserInfo(final String userId,
                      final String givenName,
                      final String familyName,
                      final String identityProvider,


### PR DESCRIPTION
This is so we can persist the UserInfo object and recreate it from storage later on.  Because all members are final, a default constructor with setters won't work, must set all fields in constructor.
